### PR TITLE
Laravel 5.4 share removed

### DIFF
--- a/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
@@ -51,8 +51,7 @@ class NewrelicServiceProvider extends ServiceProvider
 	 */
 	public function register()
 	{
-		$this->app['newrelic'] = $this->app->share(
-			function ( $app ) {
+		$this->app->singleton('newrelic', function ( $app ) {
 				return new Newrelic( $app['config']->get( 'newrelic.throw_if_not_installed' ) );
 			}
 		);


### PR DESCRIPTION
Changed the share method to singleton, now is compatible with Laravel 5.4